### PR TITLE
Force Ruby 3.4

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.4", "3.3"]
+        ruby: ["3.4"]
         gemfile:
           - Gemfile
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
   rubocop-fnando: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   NewCops: enable
   Exclude:
     - vendor/**/*
@@ -15,4 +15,7 @@ Naming/FileName:
     - API_DESIGN.rb
 
 Style/FetchEnvVar:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/API_DESIGN.rb
+++ b/API_DESIGN.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # config/app.rb
 MyApp = App.new do
   # Can be inline or defined on config/routes.rb

--- a/lib/zee.rb
+++ b/lib/zee.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rack"
 require "mini_mime"
 require "tilt"

--- a/lib/zee/app.rb
+++ b/lib/zee/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class App
     # This error is raised whenever the app is initialized more than once.

--- a/lib/zee/cli.rb
+++ b/lib/zee/cli.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "thor"
 require "shellwords"
 require "securerandom"

--- a/lib/zee/cli/secrets.rb
+++ b/lib/zee/cli/secrets.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class CLI < Thor
     class Secrets < Thor

--- a/lib/zee/config.rb
+++ b/lib/zee/config.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   # The configuration for the application.
   # It uses {https://rubygems.org/gems/superconfig SuperConfig} to define the

--- a/lib/zee/constants.rb
+++ b/lib/zee/constants.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   RACK_ZEE_APP = "zee.app"
   HTTP_ACCEPT = "HTTP_ACCEPT"

--- a/lib/zee/controller.rb
+++ b/lib/zee/controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   # Raised when a template is missing.
   MissingTemplateError = Class.new(StandardError)

--- a/lib/zee/encrypted_file.rb
+++ b/lib/zee/encrypted_file.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "base64"
 require "openssl"
 

--- a/lib/zee/environment.rb
+++ b/lib/zee/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Environment
     NAMES = %i[development test production local].freeze

--- a/lib/zee/generators/app.rb
+++ b/lib/zee/generators/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Generator < Thor::Group
     include Thor::Actions

--- a/lib/zee/generators/app/app/controllers/base.rb
+++ b/lib/zee/generators/app/app/controllers/base.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Controllers
   class Base < Zee::Controller
   end

--- a/lib/zee/generators/app/app/controllers/pages.rb
+++ b/lib/zee/generators/app/app/controllers/pages.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Controllers
   class Pages < Base
     def home

--- a/lib/zee/generators/app/config/boot.rb
+++ b/lib/zee/generators/app/config/boot.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 # Set up gems listed in the Gemfile.

--- a/lib/zee/generators/app/config/environment.rb
+++ b/lib/zee/generators/app/config/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "app"
 
 App.initialize!

--- a/lib/zee/generators/app/config/puma.rb
+++ b/lib/zee/generators/app/config/puma.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # https://puma.io/puma/Puma/DSL.html
 threads_count = ENV.fetch("APP_MAX_THREADS", 3)
 threads threads_count, threads_count

--- a/lib/zee/generators/app/config/routes.rb
+++ b/lib/zee/generators/app/config/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 App.routes do
   root to: "pages#home"
 end

--- a/lib/zee/headers.rb
+++ b/lib/zee/headers.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Headers
     def initialize

--- a/lib/zee/master_key.rb
+++ b/lib/zee/master_key.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class MasterKey
     MissingKeyError = Class.new(StandardError)

--- a/lib/zee/request.rb
+++ b/lib/zee/request.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Request < ::Rack::Request
     # The path of the request, without any trailing slashes.

--- a/lib/zee/request_handler.rb
+++ b/lib/zee/request_handler.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   # @private
   class RequestHandler

--- a/lib/zee/response.rb
+++ b/lib/zee/response.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Response
     # The body of the response.

--- a/lib/zee/route.rb
+++ b/lib/zee/route.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Route
     attr_reader :path, :via, :to, :as, :constraints, :defaults, :matcher

--- a/lib/zee/routes.rb
+++ b/lib/zee/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Routes
     def initialize(&)

--- a/lib/zee/secrets.rb
+++ b/lib/zee/secrets.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   class Secrets
     # Initialize the secrets object.

--- a/lib/zee/version.rb
+++ b/lib/zee/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Zee
   VERSION = "0.0.0"
 end

--- a/test/fixtures/app/app/controllers/base.rb
+++ b/test/fixtures/app/app/controllers/base.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Controllers
   class Base < Zee::Controller
   end

--- a/test/fixtures/app/app/controllers/pages.rb
+++ b/test/fixtures/app/app/controllers/pages.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Controllers
   class Pages < Base
     def home

--- a/test/fixtures/app/config/app.rb
+++ b/test/fixtures/app/config/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "boot"
 
 App = Zee::App.new

--- a/test/fixtures/app/config/boot.rb
+++ b/test/fixtures/app/config/boot.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 # Set up gems listed in the Gemfile.

--- a/test/fixtures/app/config/environment.rb
+++ b/test/fixtures/app/config/environment.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative "app"
 
 App.initialize!

--- a/test/fixtures/app/config/puma.rb
+++ b/test/fixtures/app/config/puma.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # https://puma.io/puma/Puma/DSL.html
 threads_count = ENV.fetch("APP_MAX_THREADS", 3)
 threads threads_count, threads_count

--- a/test/fixtures/app/config/routes.rb
+++ b/test/fixtures/app/config/routes.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 App.routes do
   root to: "pages#home"
 end

--- a/test/support/sample_app/app.rb
+++ b/test/support/sample_app/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 SampleApp = Zee::App.new do
   self.root = Pathname(__dir__)
 

--- a/test/support/sample_app/app/controllers/pages.rb
+++ b/test/support/sample_app/app/controllers/pages.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Controllers
   class Pages < Zee::Controller
     def home

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "simplecov"
 SimpleCov.start
 

--- a/test/zee/app_test.rb
+++ b/test/zee/app_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class AppTest < Minitest::Test

--- a/test/zee/cli/secrets_test.rb
+++ b/test/zee/cli/secrets_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class SecretsTest < Minitest::Test

--- a/test/zee/config_test.rb
+++ b/test/zee/config_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class ConfigTest < Minitest::Test

--- a/test/zee/encrypted_file_test.rb
+++ b/test/zee/encrypted_file_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class EncryptedFileTest < Minitest::Test

--- a/test/zee/environment_test.rb
+++ b/test/zee/environment_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class EnvironmentTest < Minitest::Test

--- a/test/zee/generators/app_test.rb
+++ b/test/zee/generators/app_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class AppTest < Minitest::Test

--- a/test/zee/headers_test.rb
+++ b/test/zee/headers_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class HeadersTest < Minitest::Test

--- a/test/zee/master_key_test.rb
+++ b/test/zee/master_key_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class MasterKeyTest < Minitest::Test

--- a/test/zee/request_test.rb
+++ b/test/zee/request_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class RequestTest < Minitest::Test

--- a/test/zee/requests/render_templates_test.rb
+++ b/test/zee/requests/render_templates_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class RenderTemplatesTest < Minitest::Test

--- a/test/zee/routes_test.rb
+++ b/test/zee/routes_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class RoutesTest < Minitest::Test

--- a/test/zee/secrets_test.rb
+++ b/test/zee/secrets_test.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "test_helper"
 
 class SecretsTest < Minitest::Test

--- a/zee.gemspec
+++ b/zee.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "A mini web framework."
   spec.description = spec.summary
   spec.license     = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.4.0")
 
   github_url = "https://github.com/fnando/zee"
   github_tree_url = "#{github_url}/tree/v#{spec.version}"


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

I read a GitHub [discussion](https://github.com/fnando/zee/discussions/10) about the `frozen_string_literal` usage and I think it's a good idea to remove it from the project forcing the Ruby 3.4 version and beyond.

### Why

The `frozen_string_literal` is a good practice to avoid bugs, but it's not necessary to use it in the project since Ruby 3.4 and beyond already have this feature enabled by default.

### Known limitations

None.
