### PR TITLE
Add Rubocop to CI

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -45,6 +45,12 @@ jobs:
           bundle config path vendor/bundle
           bundle update --jobs 4 --retry 3
 
+      - name: Run RuboCop
+        env:
+          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+        run: |
+          bundle exec rubocop
+
       - name: Run Tests
         env:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

Add a rubocop step before running the test suite

### Why

I do not see a way to avoid contributors might break a rubocop cop


### Known limitations

[TODO or N/A]
